### PR TITLE
Workaround npm.ps1 interaction with &

### DIFF
--- a/src/windows/Install-DashcamCLI.ps1
+++ b/src/windows/Install-DashcamCLI.ps1
@@ -9,7 +9,7 @@ Set-StrictMode -Version Latest
 
 Write-Host "Installing Dashcam CLI $Version..."
 
-& npm install --location=global dashcam@$Version
+cmd /c npm install --location=global dashcam@$Version
 
 Write-Host "Verifying Dashcam CLI Install..."
 & dashcam --help

--- a/src/windows/Install-NodeJS.ps1
+++ b/src/windows/Install-NodeJS.ps1
@@ -42,10 +42,10 @@ Write-Host "Installing Node.js $Version..."
 # For the moment, use 16 as that matches the major version of $Version, but
 # eventually make this include the value of $Version in some way
 $env:PATH = "$Directory;$env:PATH"
-& npm config set prefix $Directory
+cmd /c npm config set prefix $Directory
 
 Write-Host "NPM configuration, local"
-& npm config list
+cmd /c npm config list
 
 Write-Host "NPM configuration, global"
-& npm config list -g
+cmd /c npm config list -g


### PR DESCRIPTION
& npm <command>
does not work on newer Node.js releases due to the way
npm.ps1 (which this resolves to) parses the command line
